### PR TITLE
Remove management of swift services

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = swifttool
-version = 0.0.1 
+version = 0.0.2 
 description = a tool that helps configure swift rings
 author = Craig Tracey
 author-email = craigtracey@gmail.com

--- a/swifttool/client.py
+++ b/swifttool/client.py
@@ -22,7 +22,8 @@ import logging
 import os
 import sys
 import yaml
-from fabric.api import env, execute, hide, parallel, sudo
+
+from fabric.api import env
 
 from swifttool.ring_defintion import ringsdef_helper
 from swifttool.manager import capman_helper
@@ -61,7 +62,7 @@ def bootstrap(args):
         raise Exception("Could not find confguration file '%s'" % args.config)
     with open(args.config, 'r') as f:
         config = yaml.load(f)
-    ringhosts = ringsdef_helper(config, args.meta, args.outdir)
+    ringsdef_helper(config, args.meta, args.outdir)
 
 
 def main():

--- a/swifttool/client.py
+++ b/swifttool/client.py
@@ -41,12 +41,6 @@ def _setup_logger(level=logging.INFO):
     logger.addHandler(log_handler)
 
 
-@parallel
-def _fab_start_swift_services():
-    with hide('running', 'stdout', 'stderr'):
-        sudo("swift-init start all", pty=False, shell=False)
-
-
 def scaleup(args):
     _manage(args)
 
@@ -68,7 +62,6 @@ def bootstrap(args):
     with open(args.config, 'r') as f:
         config = yaml.load(f)
     ringhosts = ringsdef_helper(config, args.meta, args.outdir)
-    execute(_fab_start_swift_services, hosts=ringhosts)
 
 
 def main():

--- a/swifttool/manager.py
+++ b/swifttool/manager.py
@@ -70,7 +70,8 @@ class CapacityManager(object):
             with open(self.def_file, 'w') as stream:
                 yaml.dump(cfg, stream, default_flow_style=False,
                           explicit_start=True)
-            LOG.info("Rings distributed. Sleeping for %d hours 1 minutes" % min_part_hours)
+            LOG.info("Rings distributed. Sleeping for %d "
+                     "hours 1 minutes" % min_part_hours)
             # Sleep for min_part_hours + minute
             time.sleep((min_part_hours * 60 * 60) + 60)
             # Check if rings need to be rebalanced


### PR DESCRIPTION
We cannot have two tools competing for management of Swift services. For
now, Ansible is the owner of service management.
