### PR TITLE
pin paramiko to < 2.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+paramiko<2.2
 Fabric
 PyYAML
 gitpython


### PR DESCRIPTION
With paramiko 2.2 swiftool is throwing below exception. This PR will pin paramiko<2.2

```
Exception in thread Thread-3 (most likely raised during interpreter shutdown):
Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 810, in __bootstrap_inner
  File "/opt/bbc/openstack-2016.1-bbc248/swift/local/lib/python2.7/site-packages/paramiko/transport.py", line 1875, in run
<type 'exceptions.AttributeError'>: 'NoneType' object has no attribute 'error' 
```